### PR TITLE
Re Issue #10, I've fixed items 1-4.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,18 +65,13 @@ available to you.
 To start the REST service, run the Maven `install` and `liberty:start-server` goals from the `start`
 directory:
 
-[source, role="no_copy"]
+[source]
 ----
-cd start
 mvn clean install
 mvn liberty:start-server
 ----
 
-After you start the server, you can find your artist JSON at the following URL:
-
-```
-http://localhost:9080/artists
-```
+After you start the server, you can find your artist JSON at: http://localhost:9080/artists[http://localhost:9080/artists]
 
 Any local changes to your JavaScript and HTML are picked up automatically. After you start the Open
 Liberty server, you do not need to restart it.


### PR DESCRIPTION
* removed cd start as it’s not needed - that cd is already in the Getting started section.
* removed ‘no_copy’ tag on that box because they’re commands a user would need to copy. I tested pasting both lines at once and they both paste into the terminal - you just have to press Enter to trigger the second command when the first has finished.
* made the URL into a clickable link because the user needs to click it at this point (the URL isn't just illustrative).